### PR TITLE
callback refactor complete

### DIFF
--- a/include/dispatcher.h
+++ b/include/dispatcher.h
@@ -87,6 +87,10 @@ class Dispatcher {
   // this from main() and given that, this is the right place
   void RunDispatchLoop();
 
+  static void CallBack(__attribute__((unused)) int fd,
+		       __attribute__((unused)) short what,
+		       void* interface);
+ 
  private:
 
   // For now we keep all controller interfaces on this one vector

--- a/include/interfaces/decent_uart.h
+++ b/include/interfaces/decent_uart.h
@@ -3,8 +3,11 @@
 
 #include <gflags/gflags.h>
 
-class Dispatcher; // forward reference
+class DecentUart; // forward reference to avoid cyclic dependency
+#include "dispatcher.h"
 #include "interface.h"
+
+#define DE1_MACHINE_NAME "DE1"
 
 // For reasons we read into a fixed size char[] array.  This is that size.
 #define _UART_CHARBUF_SIZE 1024
@@ -41,10 +44,6 @@ public:
 
   // Return "DecentUART" as a human readable name for this interface
   const std::string GetInterfaceName() override;
-
-  // take a string from the callback annd pass it to the dispatcher
-  // todo: this is dumb and should go away into the base class callback
-  void ReadCB() override;
 
   // return the file descriptor for the UART serial device
   int GetFileDescriptor() override;

--- a/include/interfaces/stdio_interface.h
+++ b/include/interfaces/stdio_interface.h
@@ -3,7 +3,7 @@
 
 #include <gflags/gflags.h>
 
-class Dispatcher; // forward reference
+#include "dispatcher.h"
 #include "interface.h"
 
 // StdioInterface is a class that derives Interface and specifies it for the
@@ -27,20 +27,16 @@ class StdioInterface : public Interface {
   void Init(Dispatcher *dispathcher_ptr) override;
   
   
-  // Push a string out onto the UART serial device
+  // Push a string to stdout
   void Send(const std::string message) override;
   
-  // Get a string from the UART serial device
+  // Get a string from stdin
   const std::string Recv() override;
   
-  // Return "DecentUART" as a human readable name for this interface
+  // Return "stdio" as a human readable interface name
   const std::string GetInterfaceName() override;
   
-  // take a string from the callback annd pass it to the dispatcher
-  // todo: this is dumb and should go away into the base class callback (issue #16)
-  void ReadCB() override;
-
-  // return the file descriptor for the UART serial device
+  // return the file descriptor
   int GetFileDescriptor() override;
 };
 

--- a/include/interfaces/tcp_interface.h
+++ b/include/interfaces/tcp_interface.h
@@ -3,7 +3,7 @@
 
 #include <gflags/gflags.h>
 
-class Dispatcher; // forward reference
+#include "dispatcher.h"
 #include "interface.h"
 
 // For reasons we read into a fixed size char[] array.  This is that size.
@@ -41,10 +41,6 @@ public:
 
   // Return "TcpInterface" as a human readable name for this interface
   const std::string GetInterfaceName() override;
-
-  // take a string from the callback annd pass it to the dispatcher
-  // todo: this is dumb and should go away into the base class callback
-  void ReadCB() override;
 
   // return the file descriptor for the XXX serial device
   int GetFileDescriptor() override;

--- a/include/string_util.h
+++ b/include/string_util.h
@@ -1,18 +1,15 @@
+#ifndef _STRING_UTIL_H_
+#define _STRING_UTIL_H_
+
+#include <string>
+
 const std::string WHITESPACE = " \n\r\t\f\v";
 
-std::string ltrim(const std::string& s)
-{
-	size_t start = s.find_first_not_of(WHITESPACE);
-	return (start == std::string::npos) ? "" : s.substr(start);
-}
+std::string ltrim(const std::string& s);
 
-std::string rtrim(const std::string& s)
-{
-	size_t end = s.find_last_not_of(WHITESPACE);
-	return (end == std::string::npos) ? "" : s.substr(0, end + 1);
-}
+std::string rtrim(const std::string& s);
 
-std::string trim(const std::string& s)
-{
-	return rtrim(ltrim(s));
-}
+std::string trim(const std::string& s);
+
+
+#endif

--- a/src/interfaces/decent_uart.cpp
+++ b/src/interfaces/decent_uart.cpp
@@ -9,7 +9,7 @@
 
 // Define command line flags (via gflags)
 // These can be referenced using FLAGS_[name]
-DEFINE_string(decent_device_path, "/dev/serial0", "Path to serial device where the Decent machine is connected");
+DEFINE_string(decent_device_path, "/dev/ttySC0", "Path to serial device where the Decent machine is connected");
 
 void DecentUart::Init(Dispatcher *dispatcher_ptr) {
   DLOG(INFO) << "DecentUart: Connecting to " << FLAGS_decent_device_path;
@@ -62,18 +62,10 @@ const std::string DecentUart::Recv() {
 }
 
 const std::string DecentUart::GetInterfaceName() {
-  const std::string name("DecentUART");
+  const std::string name(DE1_MACHINE_NAME);
   return name;
-}
-
-void DecentUart::ReadCB() {
-  const std::string in_string = Recv(); 
-  CHECK_NOTNULL(_dispatcher);
-  _dispatcher->DispatchFromDE(in_string);
 }
 
 int DecentUart::GetFileDescriptor() {
   return fileno(_file_handle);
 }
-
-

--- a/src/interfaces/stdio_interface.cpp
+++ b/src/interfaces/stdio_interface.cpp
@@ -34,12 +34,6 @@ const std::string StdioInterface::GetInterfaceName() {
   return name;
 }
 
-void StdioInterface::ReadCB() {
-  const std::string in_string = Recv(); 
-  CHECK_NOTNULL(_dispatcher);
-  _dispatcher->DispatchFromController(in_string, GetInterfaceName());
-}
-
 int StdioInterface::GetFileDescriptor() {
   return STDIN_FILENO;
 }

--- a/src/interfaces/tcp_interface.cpp
+++ b/src/interfaces/tcp_interface.cpp
@@ -15,6 +15,7 @@ void TcpInterface::Init(__attribute__((unused)) Dispatcher *dispatcher_ptr) {
 void TcpInterface::Init(Dispatcher *dispatcher_ptr, int file_descriptor) {
   DLOG(INFO) << "TcpInterface: Connecting to fd " << file_descriptor;
 
+  // todo: move this into the base Init override and assert that _file_handle is not null there
   _dispatcher = dispatcher_ptr;
   
   _file_handle = fdopen(file_descriptor, "r+");
@@ -50,14 +51,6 @@ const std::string TcpInterface::Recv() {
 const std::string TcpInterface::GetInterfaceName() {
   const std::string name("TcpInterface fd " + std::to_string(GetFileDescriptor()));
   return name;
-}
-
-void TcpInterface::ReadCB() {
-  CHECK_NOTNULL(_dispatcher);
-  const std::string in_string = Recv();
-  if (in_string.length() > 0) { // ensure Recv didn't fail
-    _dispatcher->DispatchFromController(in_string, GetInterfaceName());
-  }
 }
 
 int TcpInterface::GetFileDescriptor() {

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -1,0 +1,20 @@
+#include "string_util.h"
+
+#include <string>
+
+std::string ltrim(const std::string& s)
+{
+	size_t start = s.find_first_not_of(WHITESPACE);
+	return (start == std::string::npos) ? "" : s.substr(start);
+}
+
+std::string rtrim(const std::string& s)
+{
+	size_t end = s.find_last_not_of(WHITESPACE);
+	return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+}
+
+std::string trim(const std::string& s)
+{
+	return rtrim(ltrim(s));
+}


### PR DESCRIPTION
I ended up accidentally deleting all this work but it was fairly quick to do the second time.

This moves the main read callback out of Interface and back into Dispatcher where it probably belongs.  The only non-elegant / tricky bit of this is that we need to distinguish the callback originator (i.e. the DE itself vs everyone else) by something and now we are using name.  May clean this up during the uart refactor; we'll see.