### PR TITLE
Fails and frees

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -35,11 +35,13 @@ class Interface {
   // Remember: it is vital for all nonabstract Interface inheritor classes
   // to set the _dispatcher pointer (from this base class) to refer to
   // the Dispatcher* pointer (handed to this function)
-  virtual void Init(Dispatcher *) = 0;
+  // returns nonnegative on success, negative on fail
+  virtual int Init(Dispatcher *) = 0;
 
   // Convert a std::string into whatever form is needed and send it out
   // on the real interface
-  virtual void Send(const std::string /* message */) = 0;
+  // returns nonnegative on success, negative on fail
+  virtual int Send(const std::string /* message */) = 0;
 
   // Pull a single (likely newline terminated) message off the interface
   // and return it as a const std::string

--- a/include/interfaces/stdio_interface.h
+++ b/include/interfaces/stdio_interface.h
@@ -24,11 +24,11 @@ class StdioInterface : public Interface {
   
   // Attach the _dispatcher pointer
   // (little to no setup is needed for stdio)
-  void Init(Dispatcher *dispathcher_ptr) override;
+  int Init(Dispatcher *dispathcher_ptr) override;
   
   
   // Push a string to stdout
-  void Send(const std::string message) override;
+  int Send(const std::string message) override;
   
   // Get a string from stdin
   const std::string Recv() override;

--- a/include/interfaces/tcp_interface.h
+++ b/include/interfaces/tcp_interface.h
@@ -25,11 +25,11 @@ public:
   // also stash a pointer to the filehandle in _file_handle
   // for use by Recv() and Send().
   // do not call Init(Dispatcher *) directly; we need the fd
-  void Init(Dispatcher *dispatcher_ptr, int file_descriptor);
-  void Init(Dispatcher *dispatcher_ptr) override;
+  int Init(Dispatcher *dispatcher_ptr, int file_descriptor);
+  int Init(Dispatcher *dispatcher_ptr) override;
 
   // Push a string out onto the TCP device
-  void Send(const std::string message) override;
+  int Send(const std::string message) override;
 
   // Get a string from the TCP device
   const std::string Recv() override;

--- a/include/interfaces/uart_interface.h
+++ b/include/interfaces/uart_interface.h
@@ -1,0 +1,62 @@
+#ifndef _UART_INTERFACE_H
+#define  _UART_INTERFACE_H
+
+#include <gflags/gflags.h>
+#include <string>
+
+class UartInterface; // forward reference to avoid cyclic dependency
+#include "dispatcher.h"
+#include "interface.h"
+
+// For reasons we read into a fixed size char[] array.  This is that size.
+#define _UART_CHARBUF_SIZE 1024
+
+
+// Command line flag: -decent_device_path=[string]
+// Allows a user to override the path to the Decent UART device.
+// Default = /dev/serial0
+// (Per best practice see .cpp file for the DEFINE_ call)
+DECLARE_string(decent_device_path);
+
+// DecentUART is a class that derives Interface and specifies it for the
+// UART on the back of the DE1 / DE1PRO.  How to handle the pinout etc.
+// is documented elsewhere.
+//
+// For details on what an Interface class needs/does see that base
+// class interface.h directly
+class UartInterface : public Interface {
+  
+public:
+  UartInterface() {};
+
+  // Initialize the UART (115200 8N1)
+  // and attach the _dispatcher pointer
+  // also stash a pointer to the filehandle in _file_handle
+  // for use by Recv() and Send()
+  int Init(Dispatcher *dispatcher_ptr, const std::string filename, const std::string controller_name);
+  int Init(Dispatcher *dispatcher_ptr, const std::string filename);
+  int Init(Dispatcher *dispatcher_ptr) override;
+
+  // Push a string out onto the UART serial device
+  int Send(const std::string message) override;
+
+  // Get a string from the UART serial device
+  const std::string Recv() override;
+
+  // Return "DecentUART" as a human readable name for this interface
+  const std::string GetInterfaceName() override;
+
+  // return the file descriptor for the UART serial device
+  int GetFileDescriptor() override;
+  
+protected:
+  // this is a place to hang onto the file stream
+  // for use by Recv() and Send()
+  FILE *_file_handle;
+
+  std::string _controller_name = "";
+
+};
+
+
+#endif

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -60,7 +60,12 @@ void Dispatcher::Init() {
 
 void Dispatcher::DispatchFromDE(const std::string message) {
   for (auto& interface: _controllers) { // fancy c++11 iterator shit
-    interface->Send(message);
+    int sent = interface->Send(message);
+    if (sent < 0) {
+      LOG(INFO) << "Dispatcher: Send to " << interface->GetInterfaceName() << " failed; freeing.";
+      RemoveAndFreeController(interface);
+      return;
+    }
     VLOG(4) << "Dispatcher:  >>> Sent " << trim(message) << " to " << interface->GetInterfaceName();
   }
 }

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -168,10 +168,18 @@ void Dispatcher::RunDispatchLoop() {
 }
 
 void Dispatcher::CallBack(__attribute__((unused)) int fd,
-	      __attribute__((unused)) short what,
-	      void* interface_ptr) {
+			  __attribute__((unused)) short what,
+			  void* interface_ptr) {
   Interface *interface = (Interface *)interface_ptr;
-  const std::string in_string = interface->Recv(); 
+  const std::string in_string = interface->Recv();
+
+  // empty string means bad read
+  if(in_string.length() == 0) {
+    LOG(INFO) << "Dispatcher: Interface " << interface->GetInterfaceName()
+	      << " read failed.  Closing & freeing";
+    interface->_dispatcher->RemoveAndFreeController(interface);
+    return;
+  }
   if (interface->GetInterfaceName() == DE1_MACHINE_NAME) {
     interface->_dispatcher->DispatchFromDE(in_string);
   } else {

--- a/src/interfaces/stdio_interface.cpp
+++ b/src/interfaces/stdio_interface.cpp
@@ -24,13 +24,18 @@ int StdioInterface::Send(const std::string message) {
 }
 
 const std::string StdioInterface::Recv() {
-  if (!std::cin.good()) {
-    LOG(INFO) << "StdioInterface: stdin closed; exiting";
-    exit(0);
-  }
-
   std::string message;
   std::cin >> message;
+
+  // If stdin closes, we get an empty string, which allows desire
+  // to keep running.  That seems better.  But could flag-protect
+  // or just uncomment this if what we want is for desire to keep running
+  //
+  // if (!std::cin.good()) {
+  //   LOG(INFO) << "StdioInterface: stdin closed; exiting";
+  //   exit(0);
+  // }
+
   const std::string cmessage = message;
   return cmessage;
 }

--- a/src/interfaces/stdio_interface.cpp
+++ b/src/interfaces/stdio_interface.cpp
@@ -8,13 +8,19 @@
 
 #include "dispatcher.h"
 
-void StdioInterface::Init(Dispatcher *dispatcher_ptr) {
+int StdioInterface::Init(Dispatcher *dispatcher_ptr) {
   DLOG(INFO) << "StdioInterface: Connecting to stdin";
   _dispatcher = dispatcher_ptr;
+  return 1;
 }
 
-void StdioInterface::Send(const std::string message) {
+int StdioInterface::Send(const std::string message) {
   std::cout << message;
+  if (std::cout.good()) {
+    return 1;
+  } else {
+    return -1;
+  }
 }
 
 const std::string StdioInterface::Recv() {

--- a/src/interfaces/tcp_interface.cpp
+++ b/src/interfaces/tcp_interface.cpp
@@ -45,14 +45,17 @@ int TcpInterface::Send(const std::string message) {
 
 const std::string TcpInterface::Recv() {
   char in_string[_TCP_CHARBUF_SIZE] = "";
-  if (!fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle)) {
-    LOG(INFO) << "TcpInterface: Controller TCP " << GetInterfaceName()
-	      << " read failed -- Error: " << strerror(errno);
-    return std::string("");
+  fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle);
+  if (feof(_file_handle) || ferror(_file_handle)) {
+    if (strlen(in_string) > 0) {
+      LOG(WARNING) << "TcpInterface: Controller TCP " << GetInterfaceName()
+		<< " read failed; input buffer '" << in_string
+		<< "' not newline-terminated. Dropping message.";
+    }
+    return std::string("");   // empty string signals dead interface
   }
 
   const std::string message(in_string);
-  DCHECK(message.length() > 0); // we are using zero length to mean bad read
   return message;
 }
 

--- a/src/interfaces/tcp_interface.cpp
+++ b/src/interfaces/tcp_interface.cpp
@@ -48,7 +48,7 @@ const std::string TcpInterface::Recv() {
   fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle);
   if (feof(_file_handle) || ferror(_file_handle)) {
     if (strlen(in_string) > 0) {
-      LOG(WARNING) << "TcpInterface: Controller TCP " << GetInterfaceName()
+      LOG(WARNING) << "TcpInterface: Controller " << GetInterfaceName()
 		<< " read failed; input buffer '" << in_string
 		<< "' not newline-terminated. Dropping message.";
     }
@@ -60,7 +60,7 @@ const std::string TcpInterface::Recv() {
 }
 
 const std::string TcpInterface::GetInterfaceName() {
-  const std::string name("TcpInterface fd " + std::to_string(GetFileDescriptor()));
+  const std::string name("TCP:" + std::to_string(GetFileDescriptor()));
   return name;
 }
 

--- a/src/interfaces/tcp_interface.cpp
+++ b/src/interfaces/tcp_interface.cpp
@@ -1,47 +1,58 @@
 #include "interfaces/tcp_interface.h"
 
-//#include <termios.h>
 #include <glog/logging.h>
 #include <gflags/gflags.h>
 
 #include "dispatcher.h"
+#include "string_util.h"
 
-void TcpInterface::Init(Dispatcher *dispatcher_ptr, int file_descriptor) {
+int TcpInterface::Init(Dispatcher *dispatcher_ptr, int file_descriptor) {
   DLOG(INFO) << "TcpInterface: Connecting to fd " << file_descriptor;
   
   _file_handle = fdopen(file_descriptor, "r+");
   if ((file_descriptor < 0) || (_file_handle == NULL)) {
     LOG(FATAL) << "TcpInterface: Could not open " << file_descriptor
 	       << " -- Error: " << strerror(errno);
+    return -1;
   }
   LOG(INFO) << "TcpInterface: Opened " << file_descriptor;
 	    
   return Init(dispatcher_ptr);
 }
 
-void TcpInterface::Init(Dispatcher *dispatcher_ptr) {
+int TcpInterface::Init(Dispatcher *dispatcher_ptr) {
   // ensure this is OK and prevent direct calls to this function
   CHECK_NOTNULL(_file_handle);
 
   CHECK_NOTNULL(dispatcher_ptr);
   _dispatcher = dispatcher_ptr;
+  return 1;
 }
 
-void TcpInterface::Send(const std::string message) {
-  fputs(message.c_str(), _file_handle);
-  fflush(_file_handle);
-  //  fputc('\n', _file_handle);
+int TcpInterface::Send(const std::string message) {
+  std::string strip_message = trim(message);
+  int sent_str = fputs(strip_message.c_str(), _file_handle);
+  int sent_eol = fputc('\n', _file_handle);
+  int flushed = fflush(_file_handle);
+  if ((sent_str < 0) || (sent_eol < 0) || (flushed == EOF)) {
+    LOG(INFO) << "TcpInterface: Controller TCP " << GetInterfaceName()
+	      << " write failed -- Error: " << strerror(errno);
+    return -1;
+  }
+    
+  return 1;
 }
 
 const std::string TcpInterface::Recv() {
-  char in_string[_TCP_CHARBUF_SIZE];
+  char in_string[_TCP_CHARBUF_SIZE] = "";
   if (!fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle)) {
-    LOG(INFO) << "TcpInterface: interface died: " << GetInterfaceName();
-    fclose(_file_handle);
-    _dispatcher->RemoveAndFreeController(this);
+    LOG(INFO) << "TcpInterface: Controller TCP " << GetInterfaceName()
+	      << " read failed -- Error: " << strerror(errno);
+    return std::string("");
   }
 
   const std::string message(in_string);
+  DCHECK(message.length() > 0); // we are using zero length to mean bad read
   return message;
 }
 

--- a/src/interfaces/uart_interface.cpp
+++ b/src/interfaces/uart_interface.cpp
@@ -1,0 +1,92 @@
+#include "interfaces/uart_interface.h"
+
+#include <termios.h>
+#include <glog/logging.h>
+#include <gflags/gflags.h>
+
+#include "dispatcher.h"
+#include "string_util.h"
+
+
+int UartInterface::Init(Dispatcher *dispatcher_ptr, const std::string filename, const std::string controller_name) {
+  _controller_name = controller_name;
+  return Init(dispatcher_ptr, filename);
+}
+
+int UartInterface::Init(Dispatcher *dispatcher_ptr, const std::string filename) {
+  if (_controller_name.empty()) {
+    _controller_name = filename;
+    DLOG(INFO) << "UartInterface: Connecting to " << filename;
+  } else {
+    DLOG(INFO) << "UartInterface: Connecting controller " << _controller_name << " to file " << filename;
+  }
+
+  _file_handle = fopen(filename.c_str(), "r+");
+  if (_file_handle == NULL) {
+    LOG(FATAL) << "UartInterface: Could not connect to " << filename
+		<< " -- Error: " << strerror(errno);
+    return -1;
+  } 
+
+  // apply settings for the serial port (115200 8N1)
+  int file_descriptor = fileno(_file_handle);
+  struct termios settings;
+  tcgetattr(file_descriptor, &settings);
+  speed_t baud = B115200; /* baud rate */
+  cfsetospeed(&settings, baud); /* baud rate */
+  settings.c_cflag &= ~PARENB; /* no parity */
+  settings.c_cflag &= ~CSTOPB; /* 1 stop bit */
+  settings.c_cflag &= ~CSIZE;
+  settings.c_cflag |= CS8 | CLOCAL; /* 8 bits */
+  settings.c_lflag = ICANON; /* canonical mode */
+  settings.c_oflag &= ~OPOST; /* raw output */
+  tcsetattr(file_descriptor, TCSANOW, &settings); /* apply the settings */
+  tcflush(file_descriptor, TCOFLUSH);
+
+  return Init(dispatcher_ptr);
+}
+
+int UartInterface::Init(Dispatcher *dispatcher_ptr) {
+  // this function should not be called directly
+  CHECK_NOTNULL(_file_handle);
+
+  CHECK_NOTNULL(dispatcher_ptr);
+  _dispatcher = dispatcher_ptr;
+  return 1;
+}
+
+int UartInterface::Send(const std::string message) {
+  std::string strip_message = trim(message);
+  int sent_str = fputs(strip_message.c_str(), _file_handle);
+  int sent_eol = fputc('\n', _file_handle);
+  int flushed = fflush(_file_handle);
+  if ((sent_str < 0) || (sent_eol < 0) || (flushed == EOF)) {
+    LOG(INFO) << "UartInterface: Controller " << GetInterfaceName()
+	      << " write failed -- Error: " << strerror(errno);
+    return -1;
+  }
+    
+  return 1;
+}
+
+const std::string UartInterface::Recv() {
+  char in_string[_UART_CHARBUF_SIZE] = "";
+  if (!fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle)) {
+    LOG(INFO) << "TcpInterface: Controller TCP " << GetInterfaceName()
+	      << " read failed -- Error: " << strerror(errno);
+    return std::string("");
+  }
+
+  const std::string message(in_string);
+  DCHECK(message.length() > 0); // we are using zero length to mean bad read
+  return message;
+}
+
+const std::string UartInterface::GetInterfaceName() {
+  const std::string name = _controller_name;
+  return name;
+}
+
+int UartInterface::GetFileDescriptor() {
+  return fileno(_file_handle);
+}

--- a/src/interfaces/uart_interface.cpp
+++ b/src/interfaces/uart_interface.cpp
@@ -70,15 +70,18 @@ int UartInterface::Send(const std::string message) {
 }
 
 const std::string UartInterface::Recv() {
-  char in_string[_UART_CHARBUF_SIZE] = "";
-  if (!fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle)) {
-    LOG(INFO) << "TcpInterface: Controller TCP " << GetInterfaceName()
-	      << " read failed -- Error: " << strerror(errno);
-    return std::string("");
+  char in_string[_TCP_CHARBUF_SIZE] = "";
+  fgets(in_string, _TCP_CHARBUF_SIZE, _file_handle);
+  if (feof(_file_handle) || ferror(_file_handle)) {
+    if (strlen(in_string) > 0) {
+      LOG(WARNING) << "UartInterface: Controller " << GetInterfaceName()
+		<< " read failed; input buffer '" << in_string
+		<< "' not newline-terminated. Dropping message.";
+    }
+    return std::string("");   // empty string signals dead interface
   }
 
   const std::string message(in_string);
-  DCHECK(message.length() > 0); // we are using zero length to mean bad read
   return message;
 }
 


### PR DESCRIPTION
Added and some real error checking on the interfaces.  Did some ad hoc testing of tcp, seems to be in good shape.  Stdio as well.   So far the testing was ad-hoc and on Recv() fails only since write fails are hard to test (need to create e.g. a dinky filesystem or do other weird quota assertion.  Will add an issue to track.

Some decisions made here:
 - Settled on using an empty strring coming back from Interface::Recv() to signal that the read was no good, which seems to work pretty well since if these filehandles EOF then they just spam the event buffer with empty strings.
 - Decided to allow stdin to close and just get removed like any other controller, rather than terminate the program

Things not tested at all yet:
 - Send() fails of any kind
 - Failures on UART serial devices of any kind
 - Any kind of buffer overflows
